### PR TITLE
Import events from github URL

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -3,7 +3,7 @@ package events_test
 import (
 	"fmt"
 
-	events "."
+	"github.com/jonhoo/go-events"
 )
 
 // This example shows the simples example of how to listen for, and announce,


### PR DESCRIPTION
This works even on travis-ci. To get this to work locally, you just have to develop with your code in `$GOPATH/src/github.com/jonhoo/go-events` (you can clone your repo there, or go get it and then run `git remote set-url origin git@github.com:jonhoo/go-events.git` in the go-events directory if you want).
