### PR TITLE
Support independent, non-global Events objects

### DIFF
--- a/events.go
+++ b/events.go
@@ -30,13 +30,43 @@ Verbosity indicates how verbose the events library should be.
 */
 var Verbosity = 0
 
+// Events handles its own set of events.
+type Events interface {
+	// Listen will register interest in Events whose Tag have the indicated
+	// prefix.  The returned channel will receive any future matching
+	// Event.
+	//
+	// To stop listening, simply close the channel. Attempting to send on
+	// the returned channel yields undefined behaviour. It is only
+	// writeable to allow closing.
+	Listen(prefix string) chan Event
+	// Announce will register the occurance of the given Event e, and pass
+	// it along for dispatch to interested listeners.
+	Announce(event Event)
+	// Signal is a shortcut for announcing an event with only a Tag, and no
+	// Data.
+	Signal(tag string)
+}
+
 type listener struct {
 	prefix string
 	sendon chan<- Event
 }
 
-var announcements = make(chan Event)
-var listeners = make(chan listener)
+type events struct {
+	announcements chan Event
+	listeners     chan listener
+}
+
+// Construct a new, independent Events object.
+func New() Events {
+	e := &events{
+		announcements: make(chan Event),
+		listeners:     make(chan listener),
+	}
+	go e.startListening()
+	return e
+}
 
 // dispatch will notify the listener c about Event e iff
 // e.Tag.HasPrefix(c.prefix). If the listener has left (i.e. closed the
@@ -59,64 +89,82 @@ func dispatch(c listener, e Event) (present bool) {
 	return
 }
 
-// init will set up the event dispatching loop. This function *must* be called
-// for event dispatching to become operational, but this is handled by the Go
-// package loader.
-func init() {
-	go func() {
-		var clients []listener
-		for {
-			select {
-			case c := <-listeners:
-				if Verbosity > 1 {
-					fmt.Printf("events: client registered interest in prefix '%s'\n", c.prefix)
-				}
-				clients = append(clients, c)
-			case e := <-announcements:
-				if Verbosity > 0 {
-					fmt.Printf("events: event '%s' occured; data: %v\n", e.Tag, e.Data)
-				}
+// Start listening for events. Blocks forever; intended to be called in a
+// goroutine.
+func (e *events) startListening() {
+	var clients []listener
+	for {
+		select {
+		case c := <-e.listeners:
+			if Verbosity > 1 {
+				fmt.Printf("events: client registered interest in prefix '%s'\n", c.prefix)
+			}
+			clients = append(clients, c)
+		case e := <-e.announcements:
+			if Verbosity > 0 {
+				fmt.Printf("events: event '%s' occured; data: %v\n", e.Tag, e.Data)
+			}
 
-				for _, c := range clients {
-					// TODO(jon): By not checking the
-					// return value here, we are continuing
-					// to check clients that have closed
-					// their channels for matches, which
-					// could end up being slow. However,
-					// checking the return value means
-					// either we have to not execute it
-					// asynchronously (potentially causing
-					// deadlock), or we have to have a list
-					// that can be concurrently deleted
-					// from; neither of which are things we
-					// want to do just now. Patches are
-					// welcome.
-					go dispatch(c, e)
-				}
+			for _, c := range clients {
+				// TODO(jon): By not checking the return value
+				// here, we are continuing to check clients
+				// that have closed their channels for matches,
+				// which could end up being slow. However,
+				// checking the return value means either we
+				// have to not execute it asynchronously
+				// (potentially causing deadlock), or we have
+				// to have a list that can be concurrently
+				// deleted from; neither of which are things we
+				// want to do just now. Patches are welcome.
+				go dispatch(c, e)
 			}
 		}
-	}()
+	}
 }
 
-// Listen will register interest in Events whose Tag have the indicated prefix.
-// The returned channel will receive any future matching Event.
+// A global Events object, for use with package-level implementations of the
+// Events interface methods.
+var globalEvents Events
+
+// init will set up the event dispatching loop for the global Events. This
+// function *must* be called for event dispatching to become operational, but
+// this is handled by the Go package loader.
+func init() {
+	globalEvents = New()
+}
+
+func (e *events) Listen(prefix string) chan Event {
+	io := make(chan Event)
+	e.listeners <- listener{prefix, io}
+	return io
+}
+
+func (e *events) Announce(event Event) {
+	e.announcements <- event
+}
+
+func (e *events) Signal(tag string) {
+	e.Announce(Event{tag, nil})
+}
+
+// Listen will register interest in global Events whose Tag have the indicated
+// prefix. The returned channel will receive any future matching Event.
 //
 // To stop listening, simply close the channel. Attempting to send on the
 // returned channel yields undefined behaviour. It is only writeable to allow
 // closing.
 func Listen(prefix string) chan Event {
-	io := make(chan Event)
-	listeners <- listener{prefix, io}
-	return io
+	return globalEvents.Listen(prefix)
 }
 
-// Announce will register the occurance of the given Event e, and pass it along
-// for dispatch to interested listeners.
-func Announce(e Event) {
-	announcements <- e
+// Announce will register the global occurance of the given Event e, and pass
+// it along for dispatch to interested listeners.
+func Announce(event Event) {
+	globalEvents.Announce(event)
 }
 
-// Signal is a shortcut for announcing an event with only a Tag, and no Data.
+// Signal is a shortcut for announcing a global event with only a Tag, and no
+// Data.
 func Signal(tag string) {
-	Announce(Event{tag, nil})
+	globalEvents.Signal(tag)
 }

--- a/events_test.go
+++ b/events_test.go
@@ -42,3 +42,26 @@ func TestClose(t *testing.T) {
 		Announce(e)
 	}, "announce should not panic if listener leaves")
 }
+
+func TestEventsIndependence(t *testing.T) {
+	Verbosity = 3
+
+	ev1 := New()
+	ev2 := New()
+
+	c1 := ev1.Listen(".")
+	c2 := ev2.Listen(".")
+	cGlobal := Listen(".")
+	e := Event{".", nil}
+
+	go ev1.Signal(".")
+	require.Equal(t, e, <-c1)
+	require.Empty(t, c2, "other Events should not be notified")
+	require.Empty(t, cGlobal,
+		"the global Events should not be notified for created Events")
+
+	go Signal(".")
+	require.Equal(t, e, <-cGlobal)
+	require.Empty(t, c1, "global signals should not trigger others")
+	require.Empty(t, c2, "global signals should not trigger others")
+}


### PR DESCRIPTION
Adds a public New() method that creates a new object with its own set of
event channels. The created object is part of a new Events interface
with the public API: Announce, Listen and Notify.

Remains backwards-compatible by instantiating a global Events object and
forwarding the Announce, Listen and Notify methods to that object.
